### PR TITLE
Create user on host.nms.* tenant too.

### DIFF
--- a/roles/config/tasks/main.yml
+++ b/roles/config/tasks/main.yml
@@ -30,8 +30,11 @@
   set_fact:
     magmalte_pod_name: "{{ magmalte_pod.resources[0].metadata.name }}"
 
-- name: Set username and password for {{ nms_org }} organization
+- name: Set username and password for {{ nms_org }} and host organization
   kubernetes.core.k8s_exec:
     namespace: "{{ magma_namespace }}"
     pod: "{{ magmalte_pod_name }}"
-    command: yarn setAdminPassword {{ nms_org }} {{ nms_id }} {{ nms_pass }}
+    command: yarn setAdminPassword {{ item }} {{ nms_id }} {{ nms_pass }}
+  with_items:
+    - "{{ nms_org }}"
+    - "host"


### PR DESCRIPTION
In order to configure the networks seen by each one of the tenants, one must access to "host.nms.*" parent tenant.

This PR uses the  nms_id and nms_pass to create the same user in the host and in the nms_org.