### PR TITLE
Add partial support for 1.9 in magma-deployer

### DIFF
--- a/agw-deployer/README.md
+++ b/agw-deployer/README.md
@@ -125,7 +125,7 @@ After the provisioning, restart the AGW services.
 
 ```
 $ cd /var/opt/magma/docker
-$ sudo docker compose --compatibility up -d --force-recreate
+$ sudo docker-compose --compatibility up -d --force-recreate
 ```
 At this point, you can validate the connection between your AGW and Orchestrator.
 

--- a/agw-deployer/ansible/roles/agwc-compose-part1/tasks/deploy-agwc-compose-part1.yml
+++ b/agw-deployer/ansible/roles/agwc-compose-part1/tasks/deploy-agwc-compose-part1.yml
@@ -3,12 +3,34 @@
   debug:
     msg: "Monitor the execution of this task in {{ logs_local }}/agwc_compose.log"
 
-
-        
 - name: Install docker compose version of AGW (agw_install_docker.sh)
   become: yes
   shell:
     bash "{{ bin_local }}/agw_install_docker.sh" > "{{ logs_local }}/agwc_compose.log" 2>&1
+
+- name: Make docker-compose .env writable
+  become: yes
+  ansible.builtin.file:
+    path: /var/opt/magma/docker/.env
+    mode: '0600'
+
+- name: Update docker-compose .env to right image version
+  become: yes
+  ansible.builtin.lineinfile:
+    path: /var/opt/magma/docker/.env
+    regexp: '^IMAGE_VERSION='
+    line: "IMAGE_VERSION={{magma_version}}"
+
+- name: Restart AGW (docker compose)
+  become: yes
+  args:
+    chdir: /var/opt/magma/docker/
+  command: 
+    docker-compose --compatibility up -d --force-recreate
+  register: result
+- debug: 
+    var: result
+
 
   # Up to kernel reboot
 - pause:

--- a/agw-deployer/bin/agw_install_docker.sh
+++ b/agw-deployer/bin/agw_install_docker.sh
@@ -14,7 +14,7 @@ MODE=$1
 RERUN=0    # Set to 1 to skip network configuration and run ansible playbook only
 WHOAMI=$(whoami)
 MAGMA_USER="ubuntu"
-MAGMA_VERSION="${MAGMA_VERSION:-v1.8}"
+MAGMA_VERSION="${MAGMA_VERSION:-v1.9}"
 GIT_URL="${GIT_URL:-https://github.com/magma/magma.git}"
 DEPLOY_PATH="/opt/magma/lte/gateway/deploy"
 

--- a/orc8r-deployer/README.md
+++ b/orc8r-deployer/README.md
@@ -9,7 +9,7 @@ The Orc8r Deployer has two primary approaches:
 This document describes the Quick install process: https://magma.github.io/magma/docs/next/orc8r/deploy_using_ansible
 
 ```bash
-sudo bash -c "$(curl -sL https://github.com/magma/magma-deployer/raw/main/deploy-orc8r.sh)"
+sudo bash -c "$(curl -sL https://raw.githubusercontent.com/magma/magma-deployer/main/orc8r-deployer/deploy-orc8r.sh)"
 ```
 
 ## Customized Deployer
@@ -21,10 +21,8 @@ To start the process, create a deployer working environment. Do this from a logi
 ```bash
 # As ubuntu user
 cd ~
-git clone https://github.com/jblakley/magma-deployer # To change after upstreamed
-cd magma-deployer
-git checkout agw-orc8r # To change after upstreamed
-cd orc8r-deployer
+git clone https://github.com/magma/magma-deployer
+cd magma-deployer/orc8r-deployer
 sudo bash ./deploy-orc8r-bootstrap.sh $(cd ..;pwd)
 sudo su - magma
 ```

--- a/orc8r-deployer/deploy-orc8r-bootstrap.sh
+++ b/orc8r-deployer/deploy-orc8r-bootstrap.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Check if the system is Linux
+if [ $(uname) != "Linux" ]; then
+  echo "This script is only for Linux"
+  exit 1
+fi
+
+# Run as root user
+if [ $(id -u) != 0 ]; then
+  echo "Please run as root user"
+  exit 1
+fi
+
+DEFAULT_ORC8R_DOMAIN="magma.local"
+DEFAULT_NMS_ORGANIZATION_NAME="magma-test"
+DEFAULT_NMS_EMAIL_ID_AND_PASSWORD="admin"
+DEFAULT_MAGMA_API_PASSWORD="password"
+DEFAULT_RUN_PLAYBOOK="N"
+DEFAULT_DEPLOYER_PATH="$1"
+DEFAULT_ORC8R_IP=$(hostname -I | awk '{print $1}')
+GITHUB_USERNAME="jblakley"
+GITHUB_DEPLOYER_BRANCH="main"
+# MAGMA_DOCKER_REGISTRY="magmacore"
+MAGMA_DEPLOYER_REPO="magma-deployer"
+MAGMA_USER="magma"
+HOSTS_FILE="hosts.yml"
+
+# Take input from user
+read -p "Your Magma Orchestrator domain name? [${DEFAULT_ORC8R_DOMAIN}]: " ORC8R_DOMAIN
+ORC8R_DOMAIN="${ORC8R_DOMAIN:-${DEFAULT_ORC8R_DOMAIN}}"
+
+read -p "NMS organization(subdomain) name you want? [${DEFAULT_NMS_ORGANIZATION_NAME}]: " NMS_ORGANIZATION_NAME
+NMS_ORGANIZATION_NAME="${NMS_ORGANIZATION_NAME:-${DEFAULT_NMS_ORGANIZATION_NAME}}"
+
+read -p "Set your email ID for NMS? [${DEFAULT_NMS_EMAIL_ID_AND_PASSWORD}]: " NMS_EMAIL_ID
+NMS_EMAIL_ID="${NMS_EMAIL_ID:-${DEFAULT_NMS_EMAIL_ID_AND_PASSWORD}}"
+
+read -p "Set your password for NMS? [${DEFAULT_NMS_EMAIL_ID_AND_PASSWORD}]: " NMS_PASSWORD
+NMS_PASSWORD="${NMS_PASSWORD:-${DEFAULT_NMS_EMAIL_ID_AND_PASSWORD}}"
+
+read -p "Set your password for the API Browser Certificate? [${DEFAULT_MAGMA_API_PASSWORD}]: " MAGMA_API_PASSWORD
+MAGMA_API_PASSWORD="${MAGMA_API_PASSWORD:-${DEFAULT_MAGMA_API_PASSWORD}}"
+
+read -p "Set the Orchestrator IP Address [${DEFAULT_ORC8R_IP}]: " ORC8R_IP
+ORC8R_IP="${ORC8R_IP:-${DEFAULT_ORC8R_IP}}"
+
+read -p "If you've already cloned magma-deployer, enter the path here: [${DEFAULT_DEPLOYER_PATH}]: " DEPLOYER_PATH
+DEPLOYER_PATH="${DEPLOYER_PATH:-${DEFAULT_DEPLOYER_PATH}}"
+
+read -p "Run ansible-playbook deploy-orc8r.sh on completion? [y/N]: [${DEFAULT_RUN_PLAYBOOK}]: " RUN_PLAYBOOK
+RUN_PLAYBOOK="${RUN_PLAYBOOK:-${DEFAULT_RUN_PLAYBOOK}}"
+
+test -d /tmp/magma-deployer/ && rm -rf /tmp/magma-deployer/
+test -d "${DEPLOYER_PATH}" && cp -pr ${DEPLOYER_PATH} /tmp/magma-deployer/
+
+# Add repos for installing yq and ansible
+ls /etc/apt/sources.list.d|grep yq || add-apt-repository --yes ppa:rmescandon/yq
+ls /etc/apt/sources.list.d|grep ansible || add-apt-repository --yes ppa:ansible/ansible
+
+# Install yq and ansible
+which yq || apt install yq -y
+which ansible || apt install ansible -y
+
+# Create magma user and give sudo permissions
+id ${MAGMA_USER} || useradd -m ${MAGMA_USER} -s /bin/bash -G sudo
+grep ${MAGMA_USER} /etc/sudoers || echo "${MAGMA_USER} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+# switch to magma user
+su - ${MAGMA_USER} -c bash <<_
+echo ENTERING MAGMA USER EXECUTION
+# Genereta SSH key for magma user
+test -f ~/.ssh/id_rsa.pub || ssh-keygen -t rsa -f ~/.ssh/id_rsa -N ''
+test -f ~/.ssh/authorized_keys || cp ~/.ssh/id_rsa.pub ~/.ssh/authorized_keys 
+
+test -d "~/magma-deployer" && rm -rf ~/magma-deployer
+
+if test -d /tmp/magma-deployer
+then
+	cp -pr /tmp/magma-deployer ~/
+else
+	# Clone Magma Deployer repo
+	cd ~
+	git clone https://github.com/${GITHUB_USERNAME}/${MAGMA_DEPLOYER_REPO} --depth 1
+fi
+
+cd ~/${MAGMA_DEPLOYER_REPO}
+git checkout "${GITHUB_DEPLOYER_BRANCH}"
+cd orc8r-deployer
+
+# export variables for yq
+export ORC8R_IP=${ORC8R_IP}
+export MAGMA_USER=${MAGMA_USER}
+export ORC8R_DOMAIN=${ORC8R_DOMAIN}
+export NMS_ORGANIZATION_NAME=${NMS_ORGANIZATION_NAME}
+export NMS_EMAIL_ID=${NMS_EMAIL_ID}
+export NMS_PASSWORD=${NMS_PASSWORD}
+export MAGMA_API_PASSWORD=${MAGMA_API_PASSWORD}
+export RUN_PLAYBOOK=${RUN_PLAYBOOK}
+
+# Update values to the config file
+yq e '.all.hosts = env(ORC8R_IP)' -i ${HOSTS_FILE}
+yq e '.all.vars.ansible_user = env(MAGMA_USER)' -i ${HOSTS_FILE}
+yq e '.all.vars.orc8r_domain = env(ORC8R_DOMAIN)' -i ${HOSTS_FILE}
+yq e '.all.vars.nms_org = env(NMS_ORGANIZATION_NAME)' -i ${HOSTS_FILE}
+yq e '.all.vars.nms_id = env(NMS_EMAIL_ID)' -i ${HOSTS_FILE}
+yq e '.all.vars.nms_pass = env(NMS_PASSWORD)' -i ${HOSTS_FILE}
+yq e '.all.vars.magma_api_password = env(MAGMA_API_PASSWORD)' -i ${HOSTS_FILE}
+
+# Deploy Magma Orchestrator
+if [ "${RUN_PLAYBOOK}" = "y" ]; then
+	ansible-playbook deploy-orc8r.yml
+fi 
+_
+
+rm -rf /tmp/magma-deployer


### PR DESCRIPTION
Magma-deployer updates to support 1.9 with partial parameterization of release/branch/docker image version in the agw. It also creates `orc8r-deployer/deploy-orc8r-bootstrap.sh`.

These changes were tested in CMU Lab with both the AGW and Orc8r in KVM VMs. The testing concluded at the connection of the AGW to the Orc8r visible through NMS.

Note that, without full parameterization, these changes may be backward breaking for 1.8.

This PR is intended to get the latest fixes into magma/magma-deployer prior to work by mentees on improvements.
